### PR TITLE
Prevent Codecov failures from blocking the build

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,5 +1,5 @@
 codecov:
-  require_ci_to_pass: yes
+  require_ci_to_pass: no
 
 ignore:
   - internal/examples/proto/gen

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,4 +18,4 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           file: .sage/build/go/coverage/go-test.txt
-          fail_ci_if_error: true
+          fail_ci_if_error: false


### PR DESCRIPTION
There are several errors with codecov, that prevent it from ever passing. 
I'm taking @hug-dev 's advice, and disabling the codecov requirement. 
This will help me to unblock #220 